### PR TITLE
llama2_chat_13B and hyperparameters sweep

### DIFF
--- a/get_activations.sh
+++ b/get_activations.sh
@@ -8,5 +8,8 @@ python get_activations.py honest_llama_7B tqa_gen_end_q --device 0
 # CUDA_VISIBLE_DEVICES=0 python get_activations.py llama2_chat_7B tqa_mc2 --device 0
 # CUDA_VISIBLE_DEVICES=0 python get_activations.py llama2_chat_7B tqa_gen_end_q --device 0
 
+# CUDA_VISIBLE_DEVICES=0 python get_activations.py llama2_chat_13B tqa_mc2 --device 0
+# CUDA_VISIBLE_DEVICES=0 python get_activations.py llama2_chat_13B tqa_gen_end_q --device 0
+
 # python get_activations.py llama2_chat_70B tqa_mc2 --device 0
 # python get_activations.py llama2_chat_70B tqa_gen_end_q --device 0

--- a/results.md
+++ b/results.md
@@ -1,3 +1,5 @@
+# Reproducing the paper
+
 ```CUDA_VISIBLE_DEVICES=0 python validate_2fold.py llama_7B --num_heads 48 --alpha 15 --device 0 --num_fold 2 --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>```
 
 ```
@@ -12,7 +14,9 @@ llama_7B      0.921569       0.301471  0.252451  0.391318  2.506364     0.294378
 True*Info Score: 0.3227307173440359, True Score: 0.36467172443549545, Info Score: 0.8849896926985953, MC1 Score: 0.2606998178244403, MC2 Score: 0.40755430185175656, CE Loss: 2.4722234553098676, KL wrt Original: 0.30681129746139046
 ```
 
-```CUDA_VISIBLE_DEVICES=0 python validate_2fold.py llama2_chat_7B --num_heads 48 --alpha 15 --device 0 --num_fold 2 --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>```
+# Examples of validation at apha=15 and K=48 for LLaMa Chat
+
+```python validate_2fold.py llama2_chat_7B --num_heads 48 --alpha 15 --device 0 --num_fold 2 --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>```
 
 ```
 FOLD 0
@@ -27,7 +31,22 @@ llama2_chat_7B      0.848039       0.941176  0.416667  0.59892  2.866764     0.7
 True*Info Score: 0.8303130017427044, True Score: 0.9180209981303035, Info Score: 0.9044597056426482, MC1 Score: 0.40270986145069276, MC2 Score: 0.595233170710637, CE Loss: 2.8802879935503007, KL wrt Original: 0.7351922281086445
 ```
 
-```python validate_2fold.py llama2_chat_70B --num_heads 48 --alpha 15 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>``
+```python validate_2fold.py llama2_chat_13B --num_heads 48 --alpha 15 --device 0 --num_fold 2 --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>```
+
+```
+FOLD 0
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                  
+llama2_chat_13B       0.97555       0.662592  0.337408  0.518094  2.499073     0.304115
+FOLD 1
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                  
+llama2_chat_13B      0.946078       0.590686  0.387255  0.564319  2.486696     0.223035
+
+True*Info Score: 0.6020836791355518, True Score: 0.6266389807756844, Info Score: 0.9608142768109689, MC1 Score: 0.3623316074596098, MC2 Score: 0.5412067197590136, CE Loss: 2.4928841513395312, KL wrt Original: 0.26357506241649387
+```
+
+```python validate_2fold.py llama2_chat_70B --num_heads 48 --alpha 15 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>```
 
 ```
 FOLD 0
@@ -41,3 +60,85 @@ llama2_chat_70B      0.843137       0.627451  0.392157  0.583664  2.251657     0
 
 True*Info Score: 0.5465853446663878, True Score: 0.6254614315163718, Info Score: 0.8738913658372884, MC1 Score: 0.3757850328395417, MC2 Score: 0.5604559422561715, CE Loss: 2.206671741604805, KL wrt Original: 0.06391817056573929
 ```
+
+**It appears that `True*Info` scales *down* with the model size! To explore this futher we start with the baseline:**
+
+## Baseline at alpha=0
+
+When we set `alpha` to 0, this effectively disables ITI and *should* match the "vanilla" models (i.e. https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)
+
+This is what we *expect*:
+
+- Llama-2-Chat-7B	**57.04%**
+- Llama-2-Chat-13B	**62.18%**
+- Llama-2-Chat-70B	**64.14%**
+
+But we get slightly different `True*Info`:
+
+- Llama-2-Chat-7B	**60.05%**
+- Llama-2-Chat-13B	**63.62%**
+- Llama-2-Chat-70B	**55.41%**
+(see logs bellow)
+
+
+
+```python validate_2fold.py llama2_chat_7B --num_heads 48 --alpha 0 --device 0 --num_fold 2 --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>```
+
+```
+FOLD 0
+Metric          GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                 
+llama2_chat_7B      0.887531       0.701711  0.330073  0.510557  2.416013          0.0
+FOLD 1
+Metric          GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                 
+llama2_chat_7B      0.840686       0.698529  0.343137  0.515294  2.517075          0.0
+
+True*Info Score: 0.6049799761446524, True Score: 0.7001204516036243, Info Score: 0.8641084184284962, MC1 Score: 0.3366053022676063, MC2 Score: 0.5129253583570372, CE Loss: 2.4665440082550045, KL wrt Original: 0.0
+
+```
+
+```python validate_2fold.py llama2_chat_13B --num_heads 48 --alpha 0 --device 0 --num_fold 2 --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>```
+
+```
+FOLD 0
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                  
+llama2_chat_13B      0.909535       0.682152  0.330073  0.498951  2.252217          0.0
+FOLD 1
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2  CE Loss  KL wrt Orig
+Model                                                                                 
+llama2_chat_13B      0.914216       0.713235  0.377451  0.567272  2.36487          0.0
+
+True*Info Score: 0.6362096043277299, True Score: 0.6976934416798504, Info Score: 0.911875569298624, MC1 Score: 0.35376216501270435, MC2 Score: 0.5331115737143017, CE Loss: 2.3085431772470475, KL wrt Original: 0.0
+```
+
+ ```python validate_2fold.py llama2_chat_70B --num_heads 48 --alpha 0 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>```
+
+```
+FOLD 0
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                  
+llama2_chat_70B      0.784841       0.733496  0.344743  0.536856  2.139822          0.0
+FOLD 1
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model
+                                                                                  
+llama2_chat_70B      0.784314       0.678922  0.401961  0.589754  2.233409          0.0
+True*Info Score: 0.5540755827508845, True Score: 0.7062089505728942, Info Score: 0.7845774006424086, MC1 Score: 0.37335203029867203, MC2 Score: 0.5633051972154774, CE Loss: 2.18661566644907, KL wrt Original: 0.0
+```
+
+While the baseline `True*Info` is different from what we might expect, it's sitll ~0.6, and for 13b and 70b they are *higher* than `alpha=15`!
+
+Can this be due to wrong hyperparamenters (`alpah` and `K`)?
+
+## Hyperparameter tuning
+
+`sweep.sh` automates the process with ```nohup sweep.sh > sweep.log 2> sweep_err.log &```
+
+See `llama2_chat_70b_tuning.md` for the hyperparameter sweep for the 70b LLama2-chat. The alpha=15, K=48 from the paper may not be the optimal choice for the large model with more attention heads.
+
+# Conclusion
+
+As can be seen from `llama2_chat_70b_tuning.md`, there are *no* values of `alpha` and `K` for which `meta-llama/Llama-2-70b-chat-hf` beats the baseline of `TruthfulQA`!
+The same is true for `meta-llama/Llama-2-13b-chat-hf`. We unfortunately must conclude that ITI does not scale well beyond 7B!

--- a/utils.py
+++ b/utils.py
@@ -30,6 +30,7 @@ ENGINE_MAP = {
     'alpaca_7B': 'circulus/alpaca-7b', 
     'vicuna_7B': 'AlekseyKorshuk/vicuna-7b', 
     'llama2_chat_7B': 'meta-llama/Llama-2-7b-chat-hf', 
+    'llama2_chat_13B': 'meta-llama/Llama-2-13b-chat-hf', 
     'llama2_chat_70B': 'meta-llama/Llama-2-70b-chat-hf', 
 }
 
@@ -524,7 +525,7 @@ def alt_tqa_evaluate(models, metric_names, input_path, output_path, summary_path
                 print(err)
 
         # llama
-        if mdl in ['llama_7B', 'alpaca_7B', 'vicuna_7B', 'llama2_chat_7B', 'llama2_chat_70B']: 
+        if mdl in ['llama_7B', 'alpaca_7B', 'vicuna_7B', 'llama2_chat_7B', 'llama2_chat_13B', 'llama2_chat_70B']: 
 
             assert models[mdl] is not None, 'must provide llama model'
             llama_model = models[mdl]

--- a/validation/llama2_chat_70b_tuning.md
+++ b/validation/llama2_chat_70b_tuning.md
@@ -1,0 +1,72 @@
+## Baseline
+Before looking for the best hyperparameters for applying ITI to the `llama2_chat_70B` we want to establish that the baseline model with `alpha` = 0 matches what Meta reportrd for the model!
+
+According to https://huggingface.co/meta-llama/Llama-2-70b-chat-hf the percentage of generations that are both truthful and informative over the TruthfulQA dataset is *64.14%*.
+
+We compare this with ```python validate_2fold.py llama2_chat_70B --num_heads 48 --alpha 0 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>``
+
+```
+FOLD 0
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                  
+llama2_chat_70B      0.784841       0.733496  0.344743  0.536856  2.139822          0.0
+FOLD 1
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model
+                                                                                  
+llama2_chat_70B      0.784314       0.678922  0.401961  0.589754  2.233409          0.0
+True*Info Score: 0.5540755827508845, True Score: 0.7062089505728942, Info Score: 0.7845774006424086, MC1 Score: 0.37335203029867203, MC2 Score: 0.5633051972154774, CE Loss: 2.18661566644907, KL wrt Original: 0.0
+```
+
+As you can see, is quite in line with *64.14%*, just like in the 7B model.
+
+## Validation on the https://huggingface.co/likenneth/honest_llama2_chat_70B with --num_heads 48 --alpha 15
+
+```python validate_2fold.py llama2_chat_70B --num_heads 48 --alpha 15 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>``
+
+```
+FOLD 0
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                  
+llama2_chat_70B      0.904645       0.623472  0.359413  0.537248  2.161687     0.053351
+FOLD 1
+Metric           GPT-info acc  GPT-judge acc       MC1       MC2   CE Loss  KL wrt Orig
+Model                                                                                  
+llama2_chat_70B      0.843137       0.627451  0.392157  0.583664  2.251657     0.074485
+
+True*Info Score: 0.5465853446663878, True Score: 0.6254614315163718, Info Score: 0.8738913658372884, MC1 Score: 0.3757850328395417, MC2 Score: 0.5604559422561715, CE Loss: 2.206671741604805, KL wrt Original: 0.06391817056573929
+```
+
+## Hyperparameter tunning
+
+From https://github.com/likenneth/honest_llama/pull/24#issuecomment-1838847861
+>As seen in results.md, the llama2-chat-70B is worse than the intervened llama2-chat-7B. My guess for this is that the 70B model has 80 layers and 64 heads per layer (compared to 32, 32, in 7B), so the hyper-parameters used for 7B are too small for 70B.
+
+Therfore, we will do a hyperparameter sweep, similar to Fig4 of https://arxiv.org/pdf/2306.03341.pdf, focusing on higher values of K, which are likely better for the 70b model.
+
+## Validation on the https://huggingface.co/likenneth/honest_llama2_chat_70B with --num_heads and --alpha sweep
+
+## Sweep alpha 15, K [48, 64, 80, 96]
+```
+python validate_2fold.py llama2_chat_70B --num_heads 48 --alpha 15 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>
+
+True*Info Score: 0.5465853446663878, True Score: 0.6254614315163718, Info Score: 0.8738913658372884, MC1 Score: 0.3757850328395417, MC2 Score: 0.5604559422561715, CE Loss: 2.206671741604805, KL wrt Original: 0.06391817056573929
+```
+```
+python validate_2fold.py llama2_chat_70B --num_heads 64 --alpha 15 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>
+
+True*Info Score: 0.5205856548241125, True Score: 0.5850442255141666, Info Score: 0.889822738386308, MC1 Score: 0.37333704875593265, MC2 Score: 0.5572152026040502, CE Loss: 2.203287310600281, KL wrt Original: 0.08296061750501395
+```
+```
+python validate_2fold.py llama2_chat_70B --num_heads 80 --alpha 15 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>
+
+True*Info Score: 0.5239537085765537, True Score: 0.5777002732633396, Info Score: 0.9069646195886667, MC1 Score: 0.3708920609808716, MC2 Score: 0.559189470883002, CE Loss: 2.210848189294338, KL wrt Original: 0.11165232319384813
+```
+```
+python validate_2fold.py llama2_chat_70B --num_heads 96 --alpha 15 --device 0 --num_fold 2 --model_dir <DIR> --use_center_of_mass --judge_name <curie:ft-...> --info_name <curie:ft-...>
+
+True*Info Score: 0.5288833711555987, True Score: 0.5862966824871758, Info Score: 0.9020746440385445, MC1 Score: 0.36845306582290616, MC2 Score: 0.559348046796374, CE Loss: 2.217066353857517, KL wrt Original: 0.1316926584765315
+```
+## Sweep alpha [20 25 30], K [48, 64, 80, 96]
+To automate the process `sweep.sh` script was used. Results (copied from `sweep.log`):
+

--- a/validation/sweep.sh
+++ b/validation/sweep.sh
@@ -1,0 +1,8 @@
+for alpha in 15 20 25 30; do
+    for K in 48 64 80 96; do
+        echo "alpha: $alpha K: $K"
+        python validate_2fold.py llama2_chat_70B --num_heads $K --alpha $alpha --device 0 --num_fold 2 --model_dir $MODEL_DIR --use_center_of_mass --judge_name $JUDGE --info_name $INFO
+        echo
+        echo
+    done
+done

--- a/validation/validate_2fold.py
+++ b/validation/validate_2fold.py
@@ -23,6 +23,8 @@ HF_NAMES = {
     'honest_vicuna_7B': 'results_dump/vicuna_7B_seed_42_top_48_heads_alpha_15', 
     'llama2_chat_7B': 'meta-llama/Llama-2-7b-chat-hf', 
     'honest_llama2_chat_7B': 'results_dump/llama2_chat_7B_seed_42_top_48_heads_alpha_15', 
+    'llama2_chat_13B': 'meta-llama/Llama-2-13b-chat-hf', 
+    'honest_llama2_chat_13B': 'results_dump/llama2_chat_13B_seed_42_top_48_heads_alpha_15', 
     'llama2_chat_70B': 'meta-llama/Llama-2-70b-chat-hf', 
     'honest_llama2_chat_70B': 'results_dump/llama2_chat_70B_seed_42_top_48_heads_alpha_15', 
 }
@@ -139,7 +141,7 @@ def main():
             f'splits/fold_{i}_test_seed_{args.seed}.csv', 
             f'results_dump/answer_dump/{filename}.csv', 
             f'results_dump/summary_dump/{filename}.csv', 
-            device=args.device, 
+            device="cuda", 
             interventions=interventions, 
             intervention_fn=lt_modulated_vector_add, 
             judge_name=args.judge_name, 


### PR DESCRIPTION
- Added the 13b model, `meta-llama/Llama-2-13b-chat-hf`, to see if I get as good `TruthfulQA` boost as on `Llama-2-7b-chat-hf` and the rest of 7b models. Alas no 😞 
- Did a parameter sweep of `alpha` (15 20 25 30) and `K` (48 64 80 96) for the `Llama-2-70b-chat-hf` to see if some will beat the `alpha=0` baseline. No luck either 😢 
- Documented my work

One reason I wanted yo look at the 13b is that it fits on disk and in memory of one A100, just as 7b, to eliminate possible bug sources in the 70b. But it looks like 13b does not get the `True*Info` boost either ...

I've also spot-checked `alpha=5` on 70b and 13b - no good there too.